### PR TITLE
Long Press to Save/Share

### DIFF
--- a/Hacker News/MAMReaderViewController.m
+++ b/Hacker News/MAMReaderViewController.m
@@ -18,10 +18,7 @@
 #import "UIView+AnchorPoint.h"
 
 // UIActivity
-#import "TUSafariActivity.h"
-#import "PocketAPIActivity.h"
-#import "ReadabilityActivity/ReadabilityActivity.h"
-#import "MAMInstapaperActivity.h"
+#import "MAMSingleton.h"
 
 typedef NS_ENUM(NSInteger, StoryTransitionType)
 {
@@ -257,24 +254,7 @@ typedef NS_ENUM(NSInteger, FontSizeChangeType)
         case 4:
         {
             NSURL *URL = [NSURL URLWithString:self.story.link];
-            NSMutableArray *activities = [NSMutableArray new];
-            TUSafariActivity *safariActivity = [[TUSafariActivity alloc] init];
-            [activities addObject:safariActivity];
-            PocketAPIActivity *pocketActivity = [[PocketAPIActivity alloc] init];
-            [activities addObject:pocketActivity];
-            if ([ReadabilityActivity canPerformActivity])
-            {
-                ReadabilityActivity *readabilityActivity = [[ReadabilityActivity alloc] init];
-                [activities addObject:readabilityActivity];
-            }
-            if ([MAMInstapaperActivity canPerformActivity])
-            {
-                MAMInstapaperActivity *instapaperActivity = [[MAMInstapaperActivity alloc] init];
-                [activities addObject:instapaperActivity];
-            }
-            
-            UIActivityViewController *activityViewController = [[UIActivityViewController alloc] initWithActivityItems:@[URL] applicationActivities:activities];
-            [activityViewController setExcludedActivityTypes:@[UIActivityTypePostToWeibo]];
+            UIActivityViewController *activityViewController = [[MAMSingleton sharedSingleton] activityViewControllerForURL:URL];
             
             if ([MAMHNController isPad])
             {

--- a/Hacker News/MAMSingleton.h
+++ b/Hacker News/MAMSingleton.h
@@ -1,0 +1,16 @@
+//
+//  MAMSingleton.h
+//  Hacker News
+//
+//  Created by Zach Orr on 7/9/13.
+//  Copyright (c) 2013 Maximilian Mackh. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+@interface MAMSingleton : NSObject
+
++ (MAMSingleton*)sharedSingleton;
+- (UIActivityViewController*)activityViewControllerForURL:(NSURL*)URL;
+
+@end

--- a/Hacker News/MAMSingleton.m
+++ b/Hacker News/MAMSingleton.m
@@ -1,0 +1,47 @@
+//
+//  MAMSingleton.m
+//  Hacker News
+//
+//  Created by Zach Orr on 7/9/13.
+//  Copyright (c) 2013 Maximilian Mackh. All rights reserved.
+//
+
+#import "MAMSingleton.h"
+#import "PocketAPIActivity.h"
+#import "ReadabilityActivity.h"
+#import "MAMInstapaperActivity.h"
+#import "TUSafariActivity.h"
+
+@implementation MAMSingleton
+
++(MAMSingleton*)sharedSingleton {
+    static dispatch_once_t _singletonPredicate;
+    static MAMSingleton *singleton = nil;
+    dispatch_once(&_singletonPredicate, ^{
+        singleton = [[super allocWithZone:nil] init];
+    });
+    return singleton;
+}
+
+- (UIActivityViewController*)activityViewControllerForURL:(NSURL*)URL {
+    NSMutableArray *activities = [NSMutableArray new];
+    TUSafariActivity *safariActivity = [[TUSafariActivity alloc] init];
+    [activities addObject:safariActivity];
+    PocketAPIActivity *pocketActivity = [[PocketAPIActivity alloc] init];
+    [activities addObject:pocketActivity];
+    if ([ReadabilityActivity canPerformActivity])
+    {
+        ReadabilityActivity *readabilityActivity = [[ReadabilityActivity alloc] init];
+        [activities addObject:readabilityActivity];
+    }
+    if ([MAMInstapaperActivity canPerformActivity])
+    {
+        MAMInstapaperActivity *instapaperActivity = [[MAMInstapaperActivity alloc] init];
+        [activities addObject:instapaperActivity];
+    }
+    UIActivityViewController *activityViewController = [[UIActivityViewController alloc] initWithActivityItems:@[URL] applicationActivities:activities];
+    [activityViewController setExcludedActivityTypes:@[UIActivityTypePostToWeibo]];
+    return activityViewController;
+}
+
+@end

--- a/Hacker News/MAMWebViewController.m
+++ b/Hacker News/MAMWebViewController.m
@@ -8,10 +8,7 @@
 
 #import "MAMWebViewController.h"
 #import "MAMConstants.h"
-
-#import "TUSafariActivity.h"
-#import "PocketAPIActivity.h"
-#import "ReadabilityActivity/ReadabilityActivity.h"
+#import "MAMSingleton.h"
 
 @interface MAMWebViewController () <UIGestureRecognizerDelegate>
 
@@ -70,18 +67,7 @@
 - (IBAction)safari:(id)sender
 {
     NSURL *URL = self.webView.request.URL;
-    NSMutableArray *activities = [NSMutableArray new];
-    TUSafariActivity *safariActivity = [[TUSafariActivity alloc] init];
-    [activities addObject:safariActivity];
-    PocketAPIActivity *pocketActivity = [[PocketAPIActivity alloc] init];
-    [activities addObject:pocketActivity];
-    if ([ReadabilityActivity canPerformActivity])
-    {
-        ReadabilityActivity *readabilityActivity = [[ReadabilityActivity alloc] init];
-        [activities addObject:readabilityActivity];
-    }
-    UIActivityViewController *activityViewController = [[UIActivityViewController alloc] initWithActivityItems:@[URL] applicationActivities:activities];
-    [activityViewController setExcludedActivityTypes:@[UIActivityTypePostToWeibo]];
+    UIActivityViewController *activityViewController = [[MAMSingleton sharedSingleton] activityViewControllerForURL:URL];
     
     if ([MAMHNController isPad])
     {


### PR DESCRIPTION
This is one of those features that may not be something you're looking for, but I thought it was useful

All of the code for the activity views is now stored in one place in the singleton (you were duplicating it for the web view and for the reader view, and I didn't want to duplicate it a third time in your code).

When you long press on any cell in the MAMViewController it'll bring up the activity view, so you can email, open in Safari, send to Pocket, etc without needing to load the story

![activity-view](https://f.cloud.github.com/assets/516458/772641/b3415ee8-e914-11e2-88b1-5976c431ab76.gif)
